### PR TITLE
Contributing: Add local database tip

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -230,6 +230,9 @@ By default `poe test` is using the `--reuse-db` flag to speed up testing time.
 > [!TIP]
 > If you need to ignore `--reuse-db` (e.g when testing Saleor on different versions that have different migrations) add `--create-db` argument: `poe test --create-db`
 
+> [!TIP]
+> Depending on your setup, you may want to run your Postgres on host (not inside container) to improve the test execution speed
+
 ### How to run particular tests?
 
 As running all tests is quite time-consuming, sometimes you want to run only tests from one dictionary or even just a particular test.


### PR DESCRIPTION
Recreated from original PR: https://github.com/saleor/saleor/pull/17373

I want to merge this change because it adds a tip to use local database when running tests for better speed

Kudos to @fowczarek 
